### PR TITLE
Parameter should be MARATHON_HOST instead of URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can configure `marathon-slack` via environment variables.
 
 ### Environment variables
 
-* `MARATHON_URL`: The Marathon URL (hostname or ip address) where Marathon lives. Default is `leader.mesos`, so if you don't use Mesos DNS you'll have to specify this. 
+* `MARATHON_HOST`: The Marathon Host (hostname or ip address) where Marathon lives. Default is `leader.mesos`, so if you don't use Mesos DNS you'll have to specify this. 
 * `MARATHON_PORT`: The port under which Marathon is running. Default is `8080`.
 * `MARATHON_PROTOCOL`: The protocol to access the Marathon API with. Can be either `http` or `https`. Default is `http`. 
 * `SLACK_WEBHOOK_URL`: The Slack Webhook URL (**mandatory**).

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var MarathonEventListener = require("./lib/MarathonEventListener");
 
 // Define options
 var options = {
-    marathonUrl: process.env.MARATHON_URL || "master.mesos",
+    marathonUrl: process.env.MARATHON_HOST || "master.mesos",
     marathonPort: process.env.MARATHON_PORT || 8080,
     marathonProtocol: process.env.MARATHON_PROTOCOL || "http",
     slackWebHook: process.env.SLACK_WEBHOOK_URL,


### PR DESCRIPTION
The expected value in MARATHON_URL as per implementation is Hostname or IP. Hence, the parameter should be changed to MARATHON_HOST
