### PR TITLE
add botname option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can configure `marathon-slack` via environment variables.
 * `MARATHON_PROTOCOL`: The protocol to access the Marathon API with. Can be either `http` or `https`. Default is `http`. 
 * `SLACK_WEBHOOK_URL`: The Slack Webhook URL (**mandatory**).
 * `SLACK_CHANNEL`: The name of the Slack channel to send the messages to (must contain `#`). Default is `#marathon`.
+* `SLACK_BOT_NAME`: The name of the Slack bot to send the messages from. Default is `Marathon Event Bot`.
 * `EVENT_TYPES`: The comma-separated list of event types you want to have sent to Slack, separated by comma. By default, only `deployment_info`, `deployment_success` and `deployment_failed` are activated. See below for a complete list.
 
 ### Event types

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ let options = {
 const slackHandler = new SlackHandler({
     slackWebHook: process.env.SLACK_WEBHOOK_URL,
     slackChannel: process.env.SLACK_CHANNEL || "#marathon",
-    slackBotName: process.env.SLACK_BOT_NAME || "Marathon Event Bot"
+    slackBotName: process.env.SLACK_BOT_NAME || "Marathon Event Bot",
     marathonUrl: options.marathonUrl,
     marathonPort: options.marathonPort
 });

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ let options = {
 const slackHandler = new SlackHandler({
     slackWebHook: process.env.SLACK_WEBHOOK_URL,
     slackChannel: process.env.SLACK_CHANNEL || "#marathon",
+    slackBotName: process.env.SLACK_BOT_NAME || "Marathon Event Bot"
     marathonUrl: options.marathonUrl,
     marathonPort: options.marathonPort
 });

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -22,7 +22,7 @@ function SlackHandler (options) {
 
     self.slackWebHook = options.slackWebHook|| process.env.SLACK_WEBHOOK_URL;
     self.slackChannel = options.slackChannel || process.env.SLACK_CHANNEL || "#marathon";
-    self.slackBotName = options.slackBotName || process.env.SLACK_BOT_NAME || "Marathon Event Bot"
+    self.slackBotName = options.slackBotName || process.env.SLACK_BOT_NAME || "Marathon Event Bot";
     self.marathonUrl = options.marathonUrl;
     self.marathonPort = options.marathonPort;
 

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -22,6 +22,7 @@ function SlackHandler (options) {
 
     self.slackWebHook = options.slackWebHook|| process.env.SLACK_WEBHOOK_URL;
     self.slackChannel = options.slackChannel || process.env.SLACK_CHANNEL || "#marathon";
+    self.slackBotName = options.slackBotName || process.env.SLACK_BOT_NAME || "Marathon Event Bot"
     self.marathonUrl = options.marathonUrl;
     self.marathonPort = options.marathonPort;
 
@@ -45,7 +46,7 @@ SlackHandler.prototype.renderMessage = function (event) {
     function parseEvents (event) {
 
         let message = {
-            "username": "Marathon Event Bot",
+            "username": self.options.slackBotName,
             "icon_url": "http://i.imgur.com/5FJDbGz.png",
             "mrkdwn": true
         };


### PR DESCRIPTION
Added the option to change the Bot name in an environment variable.  Useful for companies with multiple data centers.