### PR TITLE
Send messages on events where the marathon appId matches given regex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ pids
 *.pid
 *.seed
 
+# scripts
+*.sh
+
 # Dependency directories
 node_modules
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You can configure `marathon-slack` via environment variables.
 * `SLACK_CHANNEL`: The name of the Slack channel to send the messages to (must contain `#`). Default is `#marathon`.
 * `SLACK_BOT_NAME`: The name of the Slack bot to send the messages from. Default is `Marathon Event Bot`.
 * `EVENT_TYPES`: The comma-separated list of event types you want to have sent to Slack, separated by comma. By default, only `deployment_info`, `deployment_success` and `deployment_failed` are activated. See below for a complete list.
-
+* `APP_ID_REGEX`: A string regular expression to filter events by their
+  Marathon App Id. For example to send a slack message for **only** apps with id `"*-production"`.
 ### Event types
 
 Each of the following event types is pushed to Slack if not configured via the `EVENT_TYPES` environment variables:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ You can configure `marathon-slack` via environment variables.
 * `EVENT_TYPES`: The comma-separated list of event types you want to have sent to Slack, separated by comma. By default, only `deployment_info`, `deployment_success` and `deployment_failed` are activated. See below for a complete list.
 * `APP_ID_REGEX`: A string regular expression to filter events by their
   Marathon App Id. For example to send a slack message for **only** apps with id `"*-production"`.
+
 ### Event types
 
 Each of the following event types is pushed to Slack if not configured via the `EVENT_TYPES` environment variables:

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ let handlers = {};
 // Populate handler functions
 options.eventTypes.forEach(function (eventType) {
     handlers[eventType] = function (name, data) {
+        console.log("data = " + JSON.stringify(data));
         slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: data }));
     }
 });

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ let handlers = {};
 options.eventTypes.forEach(function (eventType) {
     handlers[eventType] = function (name, data) {
         if (options.whitelistRegEx.length > 0) {
-          var events = slackHandler.filterEventsByAppId(data,options.whitelistRegex[0]);
+          var events = slackHandler.filterEventsByAppId(data,options.whitelistRegEx[0]);
           events.forEach(function(ev) { 
             slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: ev }));
           });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ const SlackHandler = require("./lib/SlackHandler");
 let options = {
     marathonHost: process.env.MARATHON_HOST || "master.mesos",
     marathonPort: process.env.MARATHON_PORT || 8080,
-    marathonProtocol: process.env.MARATHON_PROTOCOL || "http"
+    marathonProtocol: process.env.MARATHON_PROTOCOL || "http",
+    whitelistRegEx: []
 };
 
 // Instantiate SlackHandler
@@ -33,16 +34,52 @@ if (process.env.EVENT_TYPES) {
     options.eventTypes = ["deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "group_change_success", "group_change_failed", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event"]
 }
 
+if (process.env.APP_ID_REGEXS) {
+    // Use environment variable
+    if (process.env.APP_ID_REGEXS.indexOf(",") > -1) {
+        options.whitelistRegEx = process.env.APP_ID_REGEXS.split(",");
+    } else {
+        options.whitelistRegEx = [process.env.APP_ID_REGEXS];
+    }
+    options.whitelistRegEx = options.whitelistRegEx.map(function(rx) { return new RegExp(rx); });
+} else { // Use the default
+    options.whitelistRegEx = []; 
+}
+
 // Placeholder for the handler functions
 let handlers = {};
 
 // Populate handler functions
 options.eventTypes.forEach(function (eventType) {
     handlers[eventType] = function (name, data) {
-        console.log("data = " + JSON.stringify(data));
-        slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: data }));
+        //console.log(JSON.stringify(data));
+        if (options.whitelistRegEx.length > 0) {
+          var events = filterEventsByAppId(data);
+          events.forEach(function(ev) { sendSlackMessage(name, ev); });          
+        } else {
+          sendSlackMessage(name, data);           
+        }
     }
 });
+
+function filterEventsByAppId(data){
+  var events = [];
+  options.whitelistRegEx.forEach(function (rx){
+    if (data.appId && rx.test(data.appId.toLowerCase())) {
+      events.push(data);
+    }
+    if (data.currentStep && data.currentStep.actions){
+      data.currentStep.actions.forEach(function(action){
+        if (rx.test(action.app.toLowerCase())) events.push(data); 
+      });
+    }
+  });
+  return events;
+}
+
+function sendSlackMessage(name, data){
+  slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: data }));
+}
 
 // Add handlers to options
 options.handlers = handlers;

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ let handlers = {};
 options.eventTypes.forEach(function (eventType) {
     handlers[eventType] = function (name, data) {
         if (options.whitelistRegEx.length > 0) {
-          var events = slackHandler.filterEventsByAppId(data,options.whitelistRegex);
+          var events = slackHandler.filterEventsByAppId(data,options.whitelistRegex[0]);
           events.forEach(function(ev) { 
             slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: ev }));
         } else {

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ options.eventTypes.forEach(function (eventType) {
           var events = slackHandler.filterEventsByAppId(data,options.whitelistRegex[0]);
           events.forEach(function(ev) { 
             slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: ev }));
+          });
         } else {
           slackHandler.sendMessage(slackHandler.renderMessage({ type: name, data: data }));
         }

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -238,4 +238,18 @@ SlackHandler.prototype.sendMessage = function (message) {
 
 };
 
+SlackHandler.prototype.filterEventsByAppId = function (data, regex){
+  var events = [];
+    if (data.appId && regex.test(data.appId.toLowerCase())) {
+      events.push(data);
+    }
+    if (data.currentStep && data.currentStep.actions){
+      data.currentStep.actions.forEach(function(action){
+        if (regex.test(action.app.toLowerCase())) events.push(data); 
+      });
+    }
+  });
+  return events;
+}
+
 module.exports = SlackHandler;

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -240,15 +240,14 @@ SlackHandler.prototype.sendMessage = function (message) {
 
 SlackHandler.prototype.filterEventsByAppId = function (data, regex){
   var events = [];
-    if (data.appId && regex.test(data.appId.toLowerCase())) {
-      events.push(data);
-    }
-    if (data.currentStep && data.currentStep.actions){
-      data.currentStep.actions.forEach(function(action){
-        if (regex.test(action.app.toLowerCase())) events.push(data); 
-      });
-    }
-  });
+  if (data.appId && regex.test(data.appId)) {
+    events.push(data);
+  }
+  if (data.currentStep && data.currentStep.actions){
+    data.currentStep.actions.forEach(function(action){
+      if (regex.test(action.app)) events.push(data); 
+    });
+  }
   return events;
 }
 


### PR DESCRIPTION
In a large data-center the operations team would like to be notified of marathon events matching some Regular Expression pattern. This pull request allows users to specify a Marathon env var `APP_ID_REGEXS` which is a comma separated list of strings to filter events by.