### PR TITLE
No events sent for eventType != deployment_*

### DIFF
--- a/lib/MarathonSlackBridge.js
+++ b/lib/MarathonSlackBridge.js
@@ -48,6 +48,10 @@ function MarathonSlackBridge (options) {
         }
     } else {
         self.eventTypes = ["deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "group_change_success", "group_change_failed", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event"]
+
+    // FIX: MarathonBusClient is filtering eventTypes
+    marathonOptions.eventTypes = self.eventTypes;
+
     }
 
     // Handle appId RegExes

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -70,6 +70,10 @@ describe("marathon-slack tests", function() {
         return slackMock.rtm.stopServer(botToken);
     });
 
+    afterEach(function () {
+        return slackMock.incomingWebhooks.reset();
+    })
+
     describe("Using MarathonEventBusMockServer", function () {
 
         this.timeout(5000);
@@ -97,6 +101,48 @@ describe("marathon-slack tests", function() {
                     const firstCall = slackMock.incomingWebhooks.calls[0];
 
                     expect(firstCall.params.attachments[0].title).to.equal("Deployment info");
+
+                });
+
+        });
+        
+        it("Should connect and receive a 'unhealthy_task_kill_event' event", () => {
+
+            return delay(250) // Wait for Marathon Slack Bridge startup
+                .then(() => {
+                    return new Promise(function (resolve, reject) {
+                        server.requestEvent("unhealthy_task_kill_event");
+                        resolve();
+                    })
+                })
+                .then(delay(1000))
+                .then(() => {
+                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                    const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                    expect(firstCall.params.attachments[0].title).to.equal("Unhealthy task was killed");
+
+                });
+        });
+
+        it("Should connect and receive a 'status_update_event' event", () => {
+
+            return delay(250) // Wait for Marathon Slack Bridge startup
+                .then(() => {
+                    return new Promise(function (resolve, reject) {
+                        server.requestEvent("status_update_event");
+                        resolve();
+                    })
+                })
+                .then(delay(1000))
+                .then(() => {
+
+                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                    const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                    expect(firstCall.params.attachments[0].title).to.equal("Status update event");
 
                 });
 

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -27,14 +27,12 @@ describe("marathon-slack tests", function() {
 
         // Configure Marathon Slack Bridge
         marathonSlackBridge = new MarathonSlackBridge({
-            marathonHost: process.env.MARATHON_HOST || "localhost",
-            marathonPort: process.env.MARATHON_PORT || 8080,
-            marathonProtocol: process.env.MARATHON_PROTOCOL || "http",
-            slackWebHook: process.env.SLACK_WEBHOOK_URL,
-            slackChannel: process.env.SLACK_CHANNEL || "#marathon",
-            slackBotName: process.env.SLACK_BOT_NAME || "Marathon Event Bot",
-            eventTypes: process.env.EVENT_TYPES || null,
-            appIdRegExes: process.env.APP_ID_REGEXES || []
+            marathonHost: "localhost",
+            marathonPort: 8080,
+            marathonProtocol: "http",
+            slackWebHook: "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+            slackChannel: "#marathon",
+            slackBotName: "Marathon Event Bot",
         });
 
         marathonSlackBridge.on("marathon_event", function(event) {

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -126,28 +126,6 @@ describe("marathon-slack tests", function() {
                 });
         });
 
-        it("Should connect and receive a 'status_update_event' event", () => {
-
-            return delay(250) // Wait for Marathon Slack Bridge startup
-                .then(() => {
-                    return new Promise(function (resolve, reject) {
-                        server.requestEvent("status_update_event");
-                        resolve();
-                    })
-                })
-                .then(delay(1000))
-                .then(() => {
-
-                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
-
-                    const firstCall = slackMock.incomingWebhooks.calls[0];
-
-                    expect(firstCall.params.attachments[0].title).to.equal("Status update event");
-
-                });
-
-        });
-
     });
 
 });


### PR DESCRIPTION
Due to the default settings in marathon-event-bus-client, no event is emitted outside the defaults: `[deployment_info", "deployment_success", "deployment_failed"]` . This PR fixes it and adds a relevant test