### PR TITLE
Handling of status_update_event & better dates

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ const marathonSlackBridge = new MarathonSlackBridge({
     slackChannel: process.env.SLACK_CHANNEL || "#marathon",
     slackBotName: process.env.SLACK_BOT_NAME || "Marathon Event Bot",
     eventTypes: process.env.EVENT_TYPES || null,
+    taskStatuses: process.env.TASK_STATUSES || null,
     appIdRegExes: process.env.APP_ID_REGEXES || []
 });
 

--- a/lib/MarathonSlackBridge.js
+++ b/lib/MarathonSlackBridge.js
@@ -35,6 +35,9 @@ function MarathonSlackBridge (options) {
     // Define event types
     self.eventTypes = [];
 
+    // Define task statuses
+    self.taskStatuses = [];
+
     // RegExes for filtering on appId
     self.appIdRegExes = [];
 
@@ -47,11 +50,23 @@ function MarathonSlackBridge (options) {
             self.eventTypes = [process.env.EVENT_TYPES];
         }
     } else {
-        self.eventTypes = ["deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "group_change_success", "group_change_failed", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event"]
+        self.eventTypes = ["deployment_info", "deployment_success", "deployment_failed", "deployment_step_success", "deployment_step_failure", "group_change_success", "group_change_failed", "failed_health_check_event", "health_status_changed_event", "unhealthy_task_kill_event", "status_update_event"]
     }
 
     // Set the event types for the marathonOptions
     marathonOptions.eventTypes = self.eventTypes;
+
+    // Handle event types if defined via options
+    if (options.taskStatuses) {
+        // Use environment variable
+        if (options.taskStatuses.indexOf(",") > -1) {
+            self.taskStatuses = options.taskStatuses.split(",");
+        } else {
+            self.taskStatuses = [options.taskStatuses];
+        }
+    } else {
+        self.taskStatuses = ["TASK_STAGING", "TASK_STARTING", "TASK_RUNNING", "TASK_FINISHED", "TASK_FAILED", "TASK_KILLING", "TASK_KILLED", "TASK_LOST"]
+    }
 
     // Handle appId RegExes
     if (process.env.APP_ID_REGEXES) {
@@ -121,8 +136,11 @@ function MarathonSlackBridge (options) {
             });
             // Apply filter conditions
             if (self.filterEventsByAppId(data)) {
-                // Render & send message
-                self.slackHandler.sendMessage(self.slackHandler.renderMessage({ type: type, data: data }));
+                // Apply status update filter
+                if (type !== "status_update_event" || self.filterStatusUpdates(data)) {
+                    // Render & send message
+                    self.slackHandler.sendMessage(self.slackHandler.renderMessage({ type: type, data: data }));
+                }
             }
         }
     });
@@ -216,6 +234,16 @@ MarathonSlackBridge.prototype.filterEventsByAppId = function (data) {
             }
             return useEvent === true;
         });
+    }
+};
+
+
+MarathonSlackBridge.prototype.filterStatusUpdates = function (data) {
+    let self = this;
+    if (self.taskStatuses.length === 0) {
+        return false;
+    } else {
+        return self.taskStatuses.indexOf(data.taskStatus) >= 0;
     }
 };
 

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -46,10 +46,6 @@ SlackHandler.prototype.renderMessage = function (event) {
         eventType: event.type,
         data: event.data
     });
-
-    function clearDateString (dateString) {
-        return "`" + dateString.replace("Z", "").replace("T", " ") + "`";
-    }
     
     function parseEvents (event) {
 

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -29,6 +29,14 @@ function SlackHandler (options) {
 // Inherit from EventEmitter
 util.inherits(SlackHandler, EventEmitter);
 
+function toUnixTimestamp (dateString) {
+    return parseInt((new Date(dateString).getTime() / 1000).toFixed(0));
+}
+
+function prepareDateToken (dateString) {
+    return "`<!date^" + toUnixTimestamp(dateString) + "^{date_num} {time_secs}|" + dateString + ">`";
+}
+
 SlackHandler.prototype.renderMessage = function (event) {
 
     let self = this;
@@ -41,10 +49,6 @@ SlackHandler.prototype.renderMessage = function (event) {
 
     function clearDateString (dateString) {
         return "`" + dateString.replace("Z", "").replace("T", " ") + "`";
-    }
-
-    function toUnixTimestamp (dateString) {
-        return parseInt((new Date(dateString).getTime() / 1000).toFixed(0));
     }
     
     function parseEvents (event) {
@@ -86,7 +90,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "Deployment was successful.",
                     "title": "Deployment success",
-                    "text": "The deployment `" + event.data.id + "` was completed successfully at " + clearDateString(event.data.timestamp),
+                    "text": "The deployment `" + event.data.id + "` was completed successfully at " + prepareDateToken(event.data.timestamp),
                     "color": "#7CD197",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -97,7 +101,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "Deployment failed.",
                     "title": "Deployment failed",
-                    "text": "The deployment `" + event.data.id + "` failed at " + clearDateString(event.data.timestamp),
+                    "text": "The deployment `" + event.data.id + "` failed at " + prepareDateToken(event.data.timestamp),
                     "color": "#ff0000",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -154,7 +158,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "Group change was completed.",
                     "title": "Group change completed",
-                    "text": "The group `" + event.data.groupId + "` completed at " + clearDateString(event.data.timestamp) + ".",
+                    "text": "The group `" + event.data.groupId + "` completed at " + prepareDateToken(event.data.timestamp) + ".",
                     "color": "#7CD197",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -165,7 +169,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "Group change failed.",
                     "title": "Group change failed",
-                    "text": "The group `" + event.data.groupId + "` failed at " + clearDateString(event.data.timestamp) + ".",
+                    "text": "The group `" + event.data.groupId + "` failed at " + prepareDateToken(event.data.timestamp) + ".",
                     "color": "#ff0000",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -176,7 +180,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "App health check failed.",
                     "title": "App health check failed",
-                    "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) failed it's health check at " + clearDateString(event.data.timestamp),
+                    "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) failed its health check at " + prepareDateToken(event.data.timestamp),
                     "color": "#ff9900",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -187,7 +191,7 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "App health status changed.",
                     "title": "App health check status changed",
-                    "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) changed it's health check status at " + clearDateString(event.data.timestamp) + " to " + (event.data.alive ? "*healthy*" : "*unhealthy*"),
+                    "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) changed its health check status at " + prepareDateToken(event.data.timestamp) + " to " + (event.data.alive ? "*healthy*" : "*unhealthy*"),
                     "color": (event.data.alive ? "#7CD197" : "#ff0000"),
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
@@ -198,11 +202,16 @@ SlackHandler.prototype.renderMessage = function (event) {
                 attachment = {
                     "fallback": "Unhealthy task was killed.",
                     "title": "Unhealthy task was killed",
-                    "text": "The app `" + event.data.appId + "` had it's task with id `" + event.data.taskId + "` killed at " + clearDateString(event.data.timestamp) + " due to an '" + event.data.reason + "' error",
+                    "text": "The app `" + event.data.appId + "` had its task with id `" + event.data.taskId + "` killed at " + prepareDateToken(event.data.timestamp) + " due to an '" + event.data.reason + "' error",
                     "color": "#ff0000",
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)
                 };
+                message.attachments = [attachment];
+                break;
+            case "status_update_event":
+                attachment = self.prepareStatusUpdateAttachment(event);
+                
                 message.attachments = [attachment];
                 break;
             default:
@@ -226,6 +235,69 @@ SlackHandler.prototype.renderMessage = function (event) {
     return parseEvents(event);
 
 };
+
+SlackHandler.prototype.prepareStatusUpdateAttachment = function (event) {
+    let title = "Task Status Update - ";
+    let color = "#0066cc";
+    
+    switch (event.data.taskStatus) {
+        case "TASK_FAILED":
+            title += "Task failed";
+            color = "#ff0000";
+
+            break;
+        case "TASK_KILLED":
+            title += "Task killed";
+            color = "#ff0000";
+            
+            break;
+        case "TASK_LOST":
+            title += "Task lost";
+            color = "#ff0000";
+            
+            break;
+        case "TASK_RUNNING":
+            title += "Task running";
+            color = "#7CD197";
+
+            break;
+        case "TASK_KILLING":
+            title += "Task killing";
+            color = "#0066cc";
+            
+            break;
+        case "TASK_FINISHED":
+            title += "Task finished";
+            color = "#0066cc";
+
+            break;
+        case "TASK_STAGING":
+            title += "Task staging";
+            color = "#0066cc";
+
+            break;
+        case "TASK_STARTING":
+            title += "Task starting";
+            color = "#0066cc";
+
+            break;
+        default:
+            title += event.data.taskStatus;
+            
+            break;
+    }
+    
+    const attachment = {
+        "fallback": title,
+        "title": title,
+        "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) changed its status to `" + event.data.taskStatus + "` at " + prepareDateToken(event.data.timestamp),
+        "color": color,
+        "mrkdwn_in": ["text"],
+        "ts": toUnixTimestamp(event.data.timestamp)
+    };
+
+    return attachment;
+}
 
 SlackHandler.prototype.sendMessage = function (message) {
 

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -124,6 +124,26 @@ describe("marathon-slack tests", function() {
                 });
         });
 
+        it("Should connect and receive a 'status_update_event' event", () => {
+
+            return delay(250) // Wait for Marathon Slack Bridge startup
+                .then(() => {
+                    return new Promise(function (resolve, reject) {
+                        server.requestEvent("status_update_event");
+                        resolve();
+                    })
+                })
+                .then(delay(1000))
+                .then(() => {
+                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                    const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                    expect(firstCall.params.attachments[0].title).to.equal("Task Status Update - Task running");
+
+                });
+        });
+
     });
 
 });


### PR DESCRIPTION
This PR handles status_update_event events with an optional filter similar to EVENT_TYPES Env var.

It also modifies the date handling and sends to Slack a date token. This way, a user will receive the date adjusted to his/her timezone. 