### PR TITLE
Add support for `health_status_changed_event` of marathon 1.4.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,10 @@ node_modules
 
 # WebStorm files
 .idea
+
+.vscode/*
+.vscode/settings.json
+.vscode/tasks.json
+.vscode/launch.json
+.vscode/extensions.json
+.history/

--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,5 @@ node_modules
 # WebStorm files
 .idea
 
-.vscode/*
-.vscode/settings.json
-.vscode/tasks.json
-.vscode/launch.json
-.vscode/extensions.json
+.vscode/
 .history/

--- a/lib/SlackHandler.js
+++ b/lib/SlackHandler.js
@@ -184,10 +184,14 @@ SlackHandler.prototype.renderMessage = function (event) {
                 message.attachments = [attachment];
                 break;
             case "health_status_changed_event":
+                let taskOrInstanceInfo = "` (with task id `" + event.data.taskId + "`)";
+                if(event.data.instanceId) {
+                    taskOrInstanceInfo = "` (with instance id `" + event.data.instanceId + "`)"
+                }
                 attachment = {
                     "fallback": "App health status changed.",
                     "title": "App health check status changed",
-                    "text": "The app `" + event.data.appId + "` (with task id `" + event.data.taskId + "`) changed its health check status at " + prepareDateToken(event.data.timestamp) + " to " + (event.data.alive ? "*healthy*" : "*unhealthy*"),
+                    "text": "The app `" + event.data.appId + taskOrInstanceInfo + " changed its health check status at " + prepareDateToken(event.data.timestamp) + " to " + (event.data.alive ? "*healthy*" : "*unhealthy*"),
                     "color": (event.data.alive ? "#7CD197" : "#ff0000"),
                     "mrkdwn_in": ["text"],
                     "ts": toUnixTimestamp(event.data.timestamp)

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "delay": "^2.0.0",
     "chai": "^4.0.0",
-    "marathon-event-bus-mock": "git+https://github.com/idanto/marathon-event-bus-mock.git",
+    "marathon-event-bus-mock": "0.1.3",
     "mocha": "^3.4.2",
     "publish-please": "^2.3.1",
     "slack-mock": "^1.0.1"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "delay": "^2.0.0",
     "chai": "^4.0.0",
-    "marathon-event-bus-mock": "^0.1.2",
+    "marathon-event-bus-mock": "git+https://github.com/idanto/marathon-event-bus-mock.git",
     "mocha": "^3.4.2",
     "publish-please": "^2.3.1",
     "slack-mock": "^1.0.1"

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -73,7 +73,7 @@ describe("marathon-slack", function () {
             this.timeout(5000);
 
             const port = 8080;
-            const server = new MarathonEventBusMockServer(port);
+            const server = new MarathonEventBusMockServer(port, true);
     
             before(server.listen.bind(server));
             after(server.close.bind(server));
@@ -226,7 +226,7 @@ describe("marathon-slack", function () {
             this.timeout(5000);
 
             const port = 8081;
-            const server = new MarathonEventBusMockServer(port, 1.4);
+            const server = new MarathonEventBusMockServer(port);
     
             before(server.listen.bind(server));
             after(server.close.bind(server));

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -8,139 +8,311 @@ const delay = require("delay");
 const MarathonSlackBridge = require("../lib/MarathonSlackBridge");
 const MarathonEventBusMockServer = require("marathon-event-bus-mock");
 
-describe("marathon-slack tests", function() {
+describe("marathon-slack", function () {
+    describe("marathon version <= 1.3", function () {
+        let slackMock;
+        const botToken = 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT';
+        let marathonSlackBridge;
 
-    let slackMock;
-    const botToken = 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT';
-    let marathonSlackBridge;
-
-    before(function () {
-        // wait for bot to get bootstrapped
-        this.timeout(30000);
-        slackMock = sm.instance;
-
-        slackMock.reset();
-
-        // Configure Marathon Slack Bridge
-        marathonSlackBridge = new MarathonSlackBridge({
-            marathonHost: "localhost",
-            marathonPort: 8080,
-            marathonProtocol: "http",
-            slackWebHook: "https://hooks.slack.com/services/XXX/YYY/ZZZ",
-            slackChannel: "#marathon",
-            slackBotName: "Marathon Event Bot",
-            publishTaskStatusUpdates: "true"
+        before(function () {
+            // wait for bot to get bootstrapped
+            this.timeout(30000);
+            slackMock = sm.instance;
+    
+            slackMock.reset();
+    
+            // Configure Marathon Slack Bridge
+            marathonSlackBridge = new MarathonSlackBridge({
+                marathonHost: "localhost",
+                marathonPort: 8080,
+                marathonProtocol: "http",
+                slackWebHook: "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+                slackChannel: "#marathon",
+                slackBotName: "Marathon Event Bot",
+                publishTaskStatusUpdates: "true"
+            });
+    
+            marathonSlackBridge.on("marathon_event", function (event) {
+                console.log("Marathon event: " + JSON.stringify(event));
+            });
+    
+            marathonSlackBridge.on("sent_message", function (message) {
+                console.log("Sent message: " + JSON.stringify(message));
+            });
+    
+            marathonSlackBridge.on("received_reply", function (message) {
+                console.log("Received reply: " + JSON.stringify(message));
+            });
+    
+            marathonSlackBridge.on("subscribed", function (event) {
+                console.log(event.message);
+            });
+    
+            marathonSlackBridge.on("unsubscribed", function (event) {
+                console.log(event.message);
+            });
+    
+            marathonSlackBridge.on("error", function (event) {
+                console.log(event.message);
+            });
+    
+    
+            marathonSlackBridge.start();
+    
         });
 
-        marathonSlackBridge.on("marathon_event", function(event) {
-            console.log("Marathon event: " + JSON.stringify(event));
+        after(function () {
+            return slackMock.rtm.stopServer(botToken);
         });
 
-        marathonSlackBridge.on("sent_message", function(message) {
-            console.log("Sent message: " + JSON.stringify(message));
+        afterEach(function () {
+            return slackMock.incomingWebhooks.reset();
         });
 
-        marathonSlackBridge.on("received_reply", function(message) {
-            console.log("Received reply: " + JSON.stringify(message));
-        });
+        describe("Using MarathonEventBusMockServer", function () {
+            this.timeout(5000);
 
-        marathonSlackBridge.on("subscribed", function(event) {
-            console.log(event.message);
-        });
+            const port = 8080;
+            const server = new MarathonEventBusMockServer(port);
+    
+            before(server.listen.bind(server));
+            after(server.close.bind(server));
 
-        marathonSlackBridge.on("unsubscribed", function(event) {
-            console.log(event.message);
-        });
+            it("Should connect and receive a 'deployment_info' event", () => {
 
-        marathonSlackBridge.on("error", function(event) {
-            console.log(event.message);
-        });
-
-
-        marathonSlackBridge.start();
-
-    });
-
-    after(function () {
-        return slackMock.rtm.stopServer(botToken);
-    });
-
-    afterEach(function () {
-        return slackMock.incomingWebhooks.reset();
-    });
-
-    describe("Using MarathonEventBusMockServer", function () {
-
-        this.timeout(5000);
-
-        const port = 8080;
-        const server = new MarathonEventBusMockServer(port);
-
-        before(server.listen.bind(server));
-        after(server.close.bind(server));
-
-        it("Should connect and receive a 'deployment_info' event", () => {
-
-            return delay(250) // Wait for Marathon Slack Bridge startup
-                .then(() => {
-                    return new Promise(function (resolve, reject) {
-                        server.requestEvent("deployment_info");
-                        resolve();
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("deployment_info");
+                            resolve();
+                        })
                     })
-                })
-                .then(delay(1000))
-                .then(() => {
+                    .then(delay(1000))
+                    .then(() => {
 
-                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
 
-                    const firstCall = slackMock.incomingWebhooks.calls[0];
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
 
-                    expect(firstCall.params.attachments[0].title).to.equal("Deployment info");
+                        expect(firstCall.params.attachments[0].title).to.equal("Deployment info");
 
-                });
+                    });
 
-        });
-        
-        it("Should connect and receive a 'unhealthy_task_kill_event' event", () => {
+            });
 
-            return delay(250) // Wait for Marathon Slack Bridge startup
-                .then(() => {
-                    return new Promise(function (resolve, reject) {
-                        server.requestEvent("unhealthy_task_kill_event");
-                        resolve();
+            it("Should connect and receive a 'unhealthy_task_kill_event' event", () => {
+
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("unhealthy_task_kill_event");
+                            resolve();
+                        })
                     })
-                })
-                .then(delay(1000))
-                .then(() => {
-                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
 
-                    const firstCall = slackMock.incomingWebhooks.calls[0];
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
 
-                    expect(firstCall.params.attachments[0].title).to.equal("Unhealthy task was killed");
+                        expect(firstCall.params.attachments[0].title).to.equal("Unhealthy task was killed");
 
-                });
-        });
+                    });
+            });
 
-        it("Should connect and receive a 'status_update_event' event", () => {
+            it("Should connect and receive a 'status_update_event' event", () => {
 
-            return delay(250) // Wait for Marathon Slack Bridge startup
-                .then(() => {
-                    return new Promise(function (resolve, reject) {
-                        server.requestEvent("status_update_event");
-                        resolve();
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("status_update_event");
+                            resolve();
+                        })
                     })
-                })
-                .then(delay(1000))
-                .then(() => {
-                    expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
 
-                    const firstCall = slackMock.incomingWebhooks.calls[0];
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
 
-                    expect(firstCall.params.attachments[0].title).to.equal("Task Status Update - Task running");
+                        expect(firstCall.params.attachments[0].title).to.equal("Task Status Update - Task running");
 
-                });
+                    });
+            });
+
+            it("Should connect and receive a 'health_status_changed_event' event", () => {
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("health_status_changed_event");
+                            resolve();
+                        })
+                    })
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                        expect(firstCall.params.attachments[0].title).to.equal("App health check status changed");
+                        expect(firstCall.params.attachments[0].text).to.include("task id");
+                        expect(firstCall.params.attachments[0].text).to.not.include("undefined");
+                    });
+            });
         });
-
     });
 
+    describe("marathon version 1.4.x", function () {
+        let slackMock;
+        const botToken = 'xoxb-XXXXXXXXXXXX-TTTTTTTTTTTTTT';
+        let marathonSlackBridge;
+
+        before(function () {
+            // wait for bot to get bootstrapped
+            this.timeout(30000);
+            slackMock = sm.instance;
+    
+            slackMock.reset();
+    
+            // Configure Marathon Slack Bridge
+            marathonSlackBridge = new MarathonSlackBridge({
+                marathonHost: "localhost",
+                marathonPort: 8081,
+                marathonProtocol: "http",
+                slackWebHook: "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+                slackChannel: "#marathon",
+                slackBotName: "Marathon Event Bot",
+                publishTaskStatusUpdates: "true"
+            });
+    
+            marathonSlackBridge.on("marathon_event", function (event) {
+                console.log("Marathon event: " + JSON.stringify(event));
+            });
+    
+            marathonSlackBridge.on("sent_message", function (message) {
+                console.log("Sent message: " + JSON.stringify(message));
+            });
+    
+            marathonSlackBridge.on("received_reply", function (message) {
+                console.log("Received reply: " + JSON.stringify(message));
+            });
+    
+            marathonSlackBridge.on("subscribed", function (event) {
+                console.log(event.message);
+            });
+    
+            marathonSlackBridge.on("unsubscribed", function (event) {
+                console.log(event.message);
+            });
+    
+            marathonSlackBridge.on("error", function (event) {
+                console.log(event.message);
+            });
+    
+    
+            marathonSlackBridge.start();
+    
+        });
+
+        after(function () {
+            return slackMock.rtm.stopServer(botToken);
+        });
+
+        afterEach(function () {
+            return slackMock.incomingWebhooks.reset();
+        });
+
+        describe("Using MarathonEventBusMockServer", function () {
+            this.timeout(5000);
+
+            const port = 8081;
+            const server = new MarathonEventBusMockServer(port, 1.4);
+    
+            before(server.listen.bind(server));
+            after(server.close.bind(server));
+
+            it("Should connect and receive a 'deployment_info' event", () => {
+
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("deployment_info");
+                            resolve();
+                        })
+                    })
+                    .then(delay(1000))
+                    .then(() => {
+
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                        expect(firstCall.params.attachments[0].title).to.equal("Deployment info");
+
+                    });
+
+            });
+
+            it("Should connect and receive a 'unhealthy_task_kill_event' event", () => {
+
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("unhealthy_task_kill_event");
+                            resolve();
+                        })
+                    })
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                        expect(firstCall.params.attachments[0].title).to.equal("Unhealthy task was killed");
+
+                    });
+            });
+
+            it("Should connect and receive a 'status_update_event' event", () => {
+
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("status_update_event");
+                            resolve();
+                        })
+                    })
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                        expect(firstCall.params.attachments[0].title).to.equal("Task Status Update - Task running");
+
+                    });
+            });
+
+            it("Should connect and receive a 'health_status_changed_event' event", () => {
+
+                return delay(250) // Wait for Marathon Slack Bridge startup
+                    .then(() => {
+                        return new Promise(function (resolve, reject) {
+                            server.requestEvent("health_status_changed_event");
+                            resolve();
+                        })
+                    })
+                    .then(delay(1000))
+                    .then(() => {
+                        expect(slackMock.incomingWebhooks.calls).to.have.length(1);
+
+                        const firstCall = slackMock.incomingWebhooks.calls[0];
+
+                        expect(firstCall.params.attachments[0].title).to.equal("App health check status changed");
+                        expect(firstCall.params.attachments[0].text).to.include("instance id");
+                        expect(firstCall.params.attachments[0].text).to.not.include("undefined");
+                    });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Resolves #20 

The default behavior is still to take the `taskId` property unless there is `instanceId` property.

Currently, the marathon-event-bus-mock dependency uses my fork until the other pull request will be accepted https://github.com/tobilg/marathon-event-bus-mock/pull/1